### PR TITLE
modified the code to be compatible with python3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/venv
+/.vscode
+/*.html
+/*.txt

--- a/MDLparsetool.py
+++ b/MDLparsetool.py
@@ -61,7 +61,7 @@ def convertNumbers(s,l,toks):
     n = toks[0]
     try:
         return int(n)
-    except ValueError, ve:
+    except ValueError as ve:
         return float(n)
 
 def joinStrings(s,l,toks):
@@ -87,8 +87,8 @@ def mdlParser(mdlFilePath):
 	mdlName = Word('$'+'.'+'_'+alphas+nums)
 	mdlValue = Forward()
 	# Strings can be split over multiple lines
-	mdlString = (dblString + Optional(OneOrMore(Suppress(LineEnd()) + LineStart()
-				 + dblString)))
+	mdlString = dblString + ZeroOrMore(Suppress(LineEnd()) + dblString)
+	mdlString.set_parse_action(lambda lst: "".join(lst))
 	mdlElements = delimitedList( mdlValue )
 	mdlArray = Group(Suppress('[') + Optional(mdlElements) + Suppress(']') )
 	mdlMatrix =Group(Suppress('[') + (delimitedList(Group(mdlElements),';')) \
@@ -279,11 +279,11 @@ def main():
 	JointList = find_block(mdldata,'Block','DialogClass','JointBlock')
 	JointNameList = get_param(JointList,'Name',0)
 	ConnList = get_connection(mdldata, JointNameList)
-	print 'ConnList'
+	print('ConnList')
 	pprint(ConnList)
-	print 'ConnList[1]'
+	print('ConnList[1]')
 	pprint(ConnList[1])
-	print 'ConnList[1][1]'
+	print('ConnList[1][1]')
 	pprint(ConnList[1][1])
 	fListT = open('fourBarTemplete.txt','wb')
 


### PR DESCRIPTION
Hi @steventen, I am using this project for my studies, and I made a minor change to code to make it compatible with python 3.10. Could you please review my pull request and check if it can be merged？ If It cannot be merged, please provide the reason for me and I will make  further changes.

The main point needs to be changed was that the multi-line-string parsing method was changed due to the evolution of `pyparsing` library, so that the multi-line strings in the block shown below could not be parsed. To solve this, I made modification on line 90-91 to make the multi-line-data-parsing go on.
```
 WorkingFrames	      "Right$CS1$[0 0 0]$WORLD$WORLD$in$[1 0 0;0 1 0;0 0 1]$3x3 Transform$rad$WORLD$false$RootPart"
      "::CS1(AUTOGEN)#Right$CS2$[-122.558 14.7511 2.5]$WORLD$WORLD$in$[1 0 0;0 1 0;0 0 1]$3x3 Transform$rad$WORLD$true$"
```  

Besides, I also made some minor changes for python 3 grammars.